### PR TITLE
Change branch name from master to main.

### DIFF
--- a/trash.rb
+++ b/trash.rb
@@ -1,6 +1,6 @@
 class Trash < Formula
   desc "A command-line tool for macOS, written in Swift, that moves files to the current user's trash folder."
-  head "https://github.com/macmade/trash", :using => :git, :branch => "master"
+  head "https://github.com/macmade/trash", :using => :git, :branch => "main"
   
   depends_on :xcode => "8.0"
   


### PR DESCRIPTION
The target repository's main branch was renamed from _master_ to _main_. Installing using brew tap doesn't work anymore.

```
❯ brew install --HEAD macmade/tap/trash
==> Installing trash from macmade/tap
==> Cloning https://github.com/macmade/trash
Cloning into '/Users/vsix/Library/Caches/Homebrew/trash--git'...
fatal: Remote branch master not found in upstream origin
Error: Failed to download resource "trash"
Failure while executing; `git clone --branch master -c advice.detachedHead=false https://github.com/macmade/trash /Users/vsix/Library/Caches/Homebrew/trash--git` exited with 128. Here's the output:
Cloning into '/Users/vsix/Library/Caches/Homebrew/trash--git'...
fatal: Remote branch master not found in upstream origin


❯ brew edit macmade/tap/trash
Editing /usr/local/Homebrew/Library/Taps/macmade/homebrew-tap/trash.rb
❯ brew install --HEAD macmade/tap/trash
==> Installing trash from macmade/tap
==> Cloning https://github.com/macmade/trash
Cloning into '/Users/vsix/Library/Caches/Homebrew/trash--git'...
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
==> xcodebuild SDKROOT= SYMROOT=build
🍺  /usr/local/Cellar/trash/HEAD-5725c2c: 5 files, 280.3KB, built in 22 seconds
```